### PR TITLE
Fix email link in header

### DIFF
--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -13,7 +13,7 @@
             <span class="divider">|</span>
             <a href="https://www.facebook.com/danrschlosser">Facebook</a>
             <span class="divider">|</span>
-            <a href="mailto://dan@schlosser.io">Email</a>
+            <a href="mailto:dan@schlosser.io">Email</a>
         </h4>
     </div>
 </section>


### PR DESCRIPTION
`mailto:` links don't have the normal `//` after the colon.